### PR TITLE
[#12] Create MQTT client that publishes sensor data

### DIFF
--- a/backend/tempHumSensor.py
+++ b/backend/tempHumSensor.py
@@ -2,16 +2,21 @@ import Adafruit_DHT
 import time
 import pymongo
 import configparser
+import json
+import paho.mqtt.client as mqtt
 
 DHT_SENSOR = Adafruit_DHT.DHT11
 DHT_PIN = 4
+
 NAME = "bedroom0"
+BROKER_IP = "192.168.0.18"
+sensor_data = {"name" : NAME, "temperature" : 0, "humidity" : 0}
 
 config = configparser.ConfigParser()
 config.read("config_flask.ini")
 
 def get_sensor_measurement():
-    humidity, temperature = Adafruit_DHT.read(DHT_SENSOR, DHT_PIN)
+    humidity, temperature = Adafruit_DHT.read_retry(DHT_SENSOR, DHT_PIN)
     if humidity is not None and temperature is not None:
         if humidity >= 0.0 and humidity <= 100.0:
             return humidity, temperature
@@ -20,19 +25,19 @@ def get_sensor_measurement():
     else:
         return get_sensor_measurement()
 
+client = mqtt.Client()
+client.connect(BROKER_IP, 1883, 60)
+client.loop_start()
 
-print(get_sensor_measurement())
-
-client = pymongo.MongoClient(str(config["DATABASE"]["CONSTRING"]))
-db = client.test
-print(client.list_database_names())
-scdb = client['SCDB']
-print(scdb.list_collection_names())
-tempSens = scdb['TempSens']
 try:
-    humidity, temp = get_sensor_measurement()
-    in_dict = {"name":NAME, "humidity":humidity, "temperature":temp}
-    x = tempSens.insert_one(in_dict)
-    print("Added object with ID ", x)
+    humidity, temperature = get_sensor_measurement()
+    sensor_data["temperature"] = temperature
+    sensor_data["humidity"] = humidity
+    sensor_data["time"] = time.time()
+    
+    client.publish("sensors/dht11", json.dumps(sensor_data), 1)
+    
+    time.sleep(2)
+
 except:
-    print("Error occured")
+    print("Exception occured")


### PR DESCRIPTION
Changed current TempHumSensor script to support MQTT publishing by doing the following:

* Imported the paho-mqtt library 
* Defined the broker IP address and a sensor_data dictionary that will be transferred as JSON
* Changed sensor read to read_retry to ensure validity of data and avoid pointless subsequent checks
* Added the time when the measurement took place