### PR TITLE
[#35] Fix automated backend tests

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,23 +1,34 @@
-import sys
 from flask import Flask, jsonify
 from flask_cors import cross_origin
 import pymongo
 import configparser
+import argparse
 
 app = Flask(__name__)
 
+parser = argparse.ArgumentParser(description="Process the connection string")
+parser.add_argument('--constring', nargs='?', action='store', type=str, help='The connection string.')
+
+args, unknown = parser.parse_known_args()
+
+
+def create_client(conStr):
+    new_client = pymongo.MongoClient(conStr)
+    return new_client
+
+
+config = configparser.ConfigParser()
+config.read("config_flask.ini")
 client = None
 
-if len(sys.argv) == 1:
-    config = configparser.ConfigParser()
-    config.read("config_flask.ini")
-    print(config["DATABASE"]["CONSTRING"])
-    client = pymongo.MongoClient(str(config["DATABASE"]["CONSTRING"]))
+if args.constring is not None:
+    client = create_client(str(args.constring))
+    print("ARGS TRUE")
+else:
+    client = create_client(str(config["DATABASE"]["CONSTRING"]))
+    print("ARGS FALSE")
 
-
-elif len(sys.argv) > 1:
-    client = pymongo.MongoClient(sys.argv[1])
-
+print(client)
 db = client["SCDB"]
 
 

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -1,0 +1,5 @@
+def pytest_addoption(parser):
+    parser.addoption(
+        "--constring",
+        action="store"
+    )

--- a/backend/test_flask.py
+++ b/backend/test_flask.py
@@ -8,25 +8,25 @@ def app():
     yield flask_app
 
 
-@pytest.fixture
+@pytest.fixture()
 def client(app):
     yield app.test_client()
 
 
-def test_index(app, client):
+def test_index(client):
     rv = client.get('/')
     assert rv.status_code == 200
     assert b"No data to show" in rv.data
 
 
-def test_test_temperature(app, client):
+def test_test_temperature(client):
     rv = client.get('/test-temp')
     assert rv.status_code == 200
     expected = json.loads(rv.get_data(as_text=True))
     assert len(expected) == 5
 
 
-def test_get_boyd_orr_sensors(app, client):
+def test_get_boyd_orr_sensors(client):
     rv = client.get('/boyd-orr')
     assert rv.status_code == 200
     expected = json.loads(rv.get_data(as_text=True))

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ pymongo==3.11.0
 pyparsing==2.4.7
 pytest==6.1.2
 pytest-cov==2.10.1
+pytest-flask==1.1.0
 six==1.15.0
 toml==0.10.2
 Werkzeug==1.0.1


### PR DESCRIPTION
Closes #35 

* Created conftest.py to configure the --constring parameter
* Added --constring parameter to app.py
* app.py can choose between command line parameter if provided, or .ini file