### PR TITLE
[#101] Added progress bar with capacity

### DIFF
--- a/frontend/cypress/integration/boydOrr.spec.js
+++ b/frontend/cypress/integration/boydOrr.spec.js
@@ -15,7 +15,7 @@ describe("Boyd Orr Test", function () {
 
   it("Test the number of graphs", function () {
     let tested = cy.get("svg").its("length");
-    tested.should("eq", 10);
+    tested.should("eq", 14);
   });
 
   it("Test if correct number of levels is displayed", function () {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15081,6 +15081,11 @@
         }
       }
     },
+    "react-circular-progressbar": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/react-circular-progressbar/-/react-circular-progressbar-2.0.3.tgz",
+      "integrity": "sha512-YKN+xAShXA3gYihevbQZbavfiJxo83Dt1cUxqg/cltj4VVsRQpDr7Fg1mvjDG3x1KHGtd9NmYKvJ2mMrPwbKyw=="
+    },
     "react-collapse": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/react-collapse/-/react-collapse-5.1.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "pondjs": "^0.9.0",
     "react": "^17.0.1",
     "react-bingmaps": "^3.6.1",
+    "react-circular-progressbar": "^2.0.3",
     "react-collapse": "^5.1.0",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",

--- a/frontend/src/components/DisplayBox.js
+++ b/frontend/src/components/DisplayBox.js
@@ -1,5 +1,7 @@
 import React from "react";
+import { CircularProgressbar, buildStyles } from "react-circular-progressbar";
 import "./DisplayBox.css";
+import "react-circular-progressbar/dist/styles.css";
 
 // properties: name of the displayed item, measurements data (list of objects)
 export default class DisplayBox extends React.Component {
@@ -8,6 +10,9 @@ export default class DisplayBox extends React.Component {
   }
 
   render() {
+    const percentage = (
+      this.props.currentData.value * 100 / this.props.capacity
+    ).toFixed(2);
     return (
       <div class="displaybox">
         <h3>{this.props.name}</h3> <hr />
@@ -15,6 +20,17 @@ export default class DisplayBox extends React.Component {
         {Object.keys(this.props.currentData).map((key) => {
           return `${key}: ${this.props.currentData[key]}\n`;
         })}
+        <div style={{ width: 120, marginTop: 20 }}>
+          {this.props.capacity ? (
+            <CircularProgressbar
+              styles={buildStyles({ textSize: "20px" })}
+              value={percentage}
+              text={`${percentage}%`}
+            />
+          ) : (
+            ""
+          )}
+        </div>
       </div>
     );
   }

--- a/frontend/src/components/DisplaySensor.js
+++ b/frontend/src/components/DisplaySensor.js
@@ -44,6 +44,7 @@ export default class Level extends React.Component {
           <DisplayBox
             name={this.props.name}
             currentData={this.props.currentData}
+            capacity={this.props.capacity}
           />
           <div class="graph-box">
             <GraphComponent

--- a/frontend/src/components/Level.js
+++ b/frontend/src/components/Level.js
@@ -38,6 +38,7 @@ export default class Level extends React.Component {
               id={sensor["_id"]}
               name={sensor["name"]}
               formal={sensor["formal"]}
+              capacity={sensor["capacity"]}
               currentData={sensor["current"]}
               seriesData={sensor["history"]}
               url={this.props.url}


### PR DESCRIPTION
Closes #101 

* DisplayBox now renders progress bar based on capacity and sensor value
* Capacity is passed as props from Level to DisplaySensor to DisplayBox
* Removed DisplayBox constructor as there was no need for it