### PR TITLE
[#115] Refactor SingleSensorPage to display sensors from any collection

### DIFF
--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -18,7 +18,7 @@ function App() {
         <Route path="/library" component={Library} />
         <Route path="/outside-sensors" component={OutsideSensors} exact/>
         <Route path="/parking-spaces" component={ParkingSpaces} />
-        <Route path="/outside-sensor" component={SingleSensorPage}/>
+        <Route path="/sensor" component={SingleSensorPage}/>
         <Route path="/compare" component={Comparator} />
         <Route component={Error} />
       </Switch>

--- a/frontend/src/components/OutsideSensors.js
+++ b/frontend/src/components/OutsideSensors.js
@@ -54,7 +54,7 @@ export default class Header extends React.Component {
     this.setState({
       selectedSensor: sensorName,
     });
-    window.open("/outside-sensor?sensorid=" + sensorName);
+    window.open("/sensor?collection=OutsideSensors&sensorid=" + sensorName);
   }
 
   render() {

--- a/frontend/src/components/ParkingSpaces.js
+++ b/frontend/src/components/ParkingSpaces.js
@@ -38,7 +38,7 @@ export default class Header extends React.Component {
         },
         pushPinOption: {
           title: sensor["formalName"],
-          color: "red",
+          color: "blue",
         },
         pushPinAddHandler: {
           type: "click",

--- a/frontend/src/components/SingleSensorPage.js
+++ b/frontend/src/components/SingleSensorPage.js
@@ -11,7 +11,7 @@ export default class SingleSensorPage extends React.Component {
   componentDidMount() {
     let qParams = this.props.location.search;
     console.log(qParams);
-    axios.get("http://127.0.0.1:5000/outside-sensors" + qParams).then((res) => {
+    axios.get("http://127.0.0.1:5000/sensor" + qParams).then((res) => {
       const all_sensor = res.data;
       console.log(all_sensor);
       this.setState((state) => {


### PR DESCRIPTION
Closes #115 
* Changed routing to /sensor to render SingleSensorPage
* SSP now makes a request to the /sensor URI on the server
* Change window URL in OutsideSensor and ParkingSpaces
* Made Parking Sensors pins blue on the map